### PR TITLE
Fix client-daemon IPC desync causing "Communication error" JSON parse failures

### DIFF
--- a/crates/deezer-tui/src/client.rs
+++ b/crates/deezer-tui/src/client.rs
@@ -1627,7 +1627,12 @@ impl ViewState {
 
 pub struct Client {
     view: ViewState,
-    reader: BufReader<tokio::net::unix::OwnedReadHalf>,
+    /// Parsed messages from the daemon, produced by a dedicated reader task.
+    /// `read_line` is not cancellation-safe, so it must never be raced against
+    /// a timeout on a shared reader — that silently truncates/desyncs the
+    /// stream. Reading to completion in its own task and forwarding results
+    /// over this channel avoids that entirely.
+    server_rx: mpsc::UnboundedReceiver<io::Result<ServerMessage>>,
     writer: tokio::net::unix::OwnedWriteHalf,
     picker: Picker,
     image_tx: mpsc::UnboundedSender<(String, image::DynamicImage)>,
@@ -1649,9 +1654,28 @@ impl Client {
 
         let (image_tx, image_rx) = mpsc::unbounded_channel();
 
+        let (server_tx, server_rx) = mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(read_half);
+            loop {
+                match read_line::<ServerMessage, _>(&mut reader).await {
+                    Ok(Some(msg)) => {
+                        if server_tx.send(Ok(msg)).is_err() {
+                            break;
+                        }
+                    }
+                    Ok(None) => break, // EOF — daemon disconnected
+                    Err(e) => {
+                        let _ = server_tx.send(Err(e));
+                        break;
+                    }
+                }
+            }
+        });
+
         Ok(Self {
             view: ViewState::from_snapshot(&DaemonSnapshot::default()),
-            reader: BufReader::new(read_half),
+            server_rx,
             writer: write_half,
             picker,
             image_tx,
@@ -1794,17 +1818,12 @@ impl Client {
 
         // Wait for initial snapshot from daemon before drawing anything.
         // This avoids a brief flash of the Login screen when the user is already logged in.
-        match tokio::time::timeout(
-            Duration::from_secs(3),
-            read_line::<ServerMessage, _>(&mut self.reader),
-        )
-        .await
-        {
-            Ok(Ok(Some(ServerMessage::Snapshot(snap)))) => {
+        match tokio::time::timeout(Duration::from_secs(3), self.server_rx.recv()).await {
+            Ok(Some(Ok(ServerMessage::Snapshot(snap)))) => {
                 self.view.update_from_snapshot(snap);
             }
             _ => {
-                // Timeout or error — proceed with default state
+                // Timeout, disconnect, or error — proceed with default state
             }
         }
 
@@ -2000,34 +2019,30 @@ impl Client {
                 break;
             }
 
-            // Try to read messages from daemon (non-blocking)
-            match tokio::time::timeout(
-                Duration::from_millis(1),
-                read_line::<ServerMessage, _>(&mut self.reader),
-            )
-            .await
-            {
-                Ok(Ok(Some(ServerMessage::Snapshot(snap)))) => {
+            // Drain any messages from daemon (non-blocking; reading happens in
+            // the dedicated task spawned in `connect`, never raced against a
+            // timeout here).
+            match self.server_rx.try_recv() {
+                Ok(Ok(ServerMessage::Snapshot(snap))) => {
                     self.view.update_from_snapshot(snap);
                     self.maybe_fetch_cover_image();
                 }
-                Ok(Ok(Some(ServerMessage::Error(err)))) => {
+                Ok(Ok(ServerMessage::Error(err))) => {
                     self.view.set_status_msg(Some(format!("Error: {err}")));
                 }
-                Ok(Ok(None)) => {
+                Ok(Err(e)) => {
+                    debug!("Read error from daemon: {e}");
+                    self.view
+                        .set_status_msg(Some(format!("Communication error: {e}")));
+                }
+                Err(mpsc::error::TryRecvError::Disconnected) => {
                     // Daemon disconnected
                     self.view
                         .set_status_msg(Some(t().daemon_disconnected.into()));
                     running = false;
                 }
-                Ok(Err(e)) => {
-                    // Read/parse error — log but don't crash immediately
-                    debug!("Read error from daemon: {e}");
-                    self.view
-                        .set_status_msg(Some(format!("Communication error: {e}")));
-                }
-                Err(_) => {
-                    // Timeout — no data available, continue
+                Err(mpsc::error::TryRecvError::Empty) => {
+                    // No data available, continue
                 }
             }
 

--- a/crates/deezer-tui/src/main.rs
+++ b/crates/deezer-tui/src/main.rs
@@ -117,10 +117,13 @@ fn main() -> Result<()> {
     }
 }
 
-/// Build a current-thread runtime for the TUI client and one-shot commands.
-/// No worker thread pool — the client only does IPC + rendering.
+/// Build a runtime for the TUI client and one-shot commands.
+/// Needs a real worker thread: the main loop blocks the thread it runs on
+/// inside crossterm's synchronous `event::poll`, which would otherwise starve
+/// the background daemon-socket reader task on a current-thread runtime.
 fn build_client_runtime() -> Result<tokio::runtime::Runtime> {
-    Ok(tokio::runtime::Builder::new_current_thread()
+    Ok(tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
         .enable_all()
         .build()?)
 }


### PR DESCRIPTION
## Problem

The TUI client polls the daemon socket every frame with:

```rust
tokio::time::timeout(Duration::from_millis(1), read_line(&mut self.reader)).await
```

read_line() is not cancellation-safe: it consumes bytes from the stream while
scanning for the trailing \n, even if it hasn't found one yet. If the 1ms timeout
fires while a line is partially read, the future is dropped along with the bytes it
already buffered — but the stream's read position has already moved past them,
desyncing the framing. The next read then starts mid-message and fails to parse,
so I get errors like:

Communication error: expected value at line 1 column 1

Since the daemon broadcasts a snapshot to every client every 250ms unconditionally
(TICK_RATE in daemon.rs), this can happen with zero user input, and more often
during rapid interaction (e.g. I was scrolling in Favorites), since each navigation command
triggers an additional immediate broadcast on top of the regular ticks.

The problem happens on macOS, and not on my linux machine, but I may be using different versions so it may be unrelated.

Fix

- Move the socket read into a dedicated task per connection (mirroring the pattern
the daemon already uses for its own per-client readers) that reads each line to
completion — never raced against a timeout — and forwards parsed messages over an
mpsc channel. The main loop drains it with a non-blocking try_recv().
- That background task only gets scheduled if the runtime has a spare thread for it.
The client ran on a current_thread runtime, and its main loop blocks that single
thread synchronously inside crossterm::event::poll() every frame — which would
starve the new reader task. Switched the client runtime to multi_thread with one
worker thread so the reader task runs independently of the main loop's blocking
input polling.

Testing

Built in release mode, ran locally for an extended session including rapid
scrolling through Favorites — no more communication errors, and the daemon
disconnect/error paths still behave as before.