### PR TITLE
feat(terminal): improve terminal integration with dynamic title, panic recovery, CLI status, and completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,10 @@ sudo mv deezer-tui /usr/local/bin/deezer-tui
 ✅ Offline mode with downloaded tracks<br>
 ✅ Album/Artist miniature (require Kitty or Ghostty for real image display)<br>
 ✅ Auto update<br>
-✅ MPRIS support for Linux desktops environments : play/next track/previous track<br>
+✅ MPRIS support for Linux desktop environments : play/next track/previous track<br>
+✅ CLI controls & status line integration (`--status`, `--json`, `--volume`, etc.) for tmux, Waybar, Polybar, and scripts<br>
+✅ Shell completions generator for Bash, Zsh, and Fish (`--completions <shell>`)<br>
+✅ Dynamic terminal window/tab title with now-playing track info and panic-safe terminal restoration<br>
 
 ## In action
 

--- a/crates/deezer-tui/src/client.rs
+++ b/crates/deezer-tui/src/client.rs
@@ -4,13 +4,14 @@ use std::io;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
+use crossterm::cursor::Show;
 use crossterm::event::{
     self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton, MouseEvent,
     MouseEventKind,
 };
 use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
 use crossterm::terminal::{
-    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen, SetTitle,
 };
 use crossterm::ExecutableCommand;
 use ratatui::prelude::*;
@@ -1709,6 +1710,16 @@ pub struct Client {
     last_click: Option<(u16, u16, Instant)>,
 }
 
+/// Helper to restore standard terminal mode safely.
+pub fn restore_terminal() {
+    let mut stdout = io::stdout();
+    let _ = stdout.execute(DisableMouseCapture);
+    let _ = disable_raw_mode();
+    let _ = stdout.execute(LeaveAlternateScreen);
+    let _ = stdout.execute(Show);
+    let _ = stdout.execute(SetTitle(""));
+}
+
 impl Client {
     pub async fn connect() -> Result<Self> {
         let path = socket_path();
@@ -1843,6 +1854,20 @@ impl Client {
         });
     }
 
+    /// Update the terminal emulator window/tab title with current playback info.
+    fn update_terminal_title(&self) {
+        let title = match (&self.view.status, &self.view.current_track) {
+            (PlaybackStatus::Playing, Some(track)) => {
+                format!("deezer-tui: ▶ {} — {}", track.title, track.artist)
+            }
+            (PlaybackStatus::Paused, Some(track)) => {
+                format!("deezer-tui: ⏸ {} — {}", track.title, track.artist)
+            }
+            _ => "deezer-tui".to_string(),
+        };
+        let _ = io::stdout().execute(SetTitle(title));
+    }
+
     async fn send_cmd(&mut self, cmd: &Command) -> std::io::Result<()> {
         use tokio::io::AsyncWriteExt;
         let mut json = serde_json::to_string(cmd)
@@ -1853,6 +1878,13 @@ impl Client {
     }
 
     pub async fn run(&mut self, show_updated: bool) -> Result<()> {
+        // Setup panic hook to ensure terminal is restored cleanly if a crash occurs
+        let default_panic = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            restore_terminal();
+            default_panic(info);
+        }));
+
         // Load saved theme and opacity from config
         let config = Config::load();
         if let Some(ref theme_str) = config.theme {
@@ -1869,6 +1901,7 @@ impl Client {
         let backend = CrosstermBackend::new(io::stdout());
         let mut terminal = Terminal::new(backend)?;
         terminal.clear()?;
+        self.update_terminal_title();
 
         // Spawn update check in background (non-blocking)
         let (update_tx, mut update_rx) = mpsc::unbounded_channel::<(String, String)>();
@@ -1887,6 +1920,7 @@ impl Client {
         match tokio::time::timeout(Duration::from_secs(3), self.server_rx.recv()).await {
             Ok(Some(Ok(ServerMessage::Snapshot(snap)))) => {
                 self.view.update_from_snapshot(snap);
+                self.update_terminal_title();
             }
             _ => {
                 // Timeout, disconnect, or error — proceed with default state
@@ -1975,9 +2009,7 @@ impl Client {
                     }
                     KeyAction::WebLogin => {
                         // Suspend TUI
-                        io::stdout().execute(DisableMouseCapture)?;
-                        disable_raw_mode()?;
-                        io::stdout().execute(LeaveAlternateScreen)?;
+                        restore_terminal();
                         drop(terminal);
 
                         // Run browser login (blocking)
@@ -1989,6 +2021,7 @@ impl Client {
                         io::stdout().execute(EnableMouseCapture)?;
                         terminal = Terminal::new(CrosstermBackend::new(io::stdout()))?;
                         terminal.clear()?;
+                        self.update_terminal_title();
 
                         if let Ok(Some(arl)) = result {
                             self.view.login_loading = true;
@@ -2009,9 +2042,7 @@ impl Client {
                         })?;
 
                         // Suspend TUI so sudo can prompt for password if needed
-                        io::stdout().execute(DisableMouseCapture)?;
-                        disable_raw_mode()?;
-                        io::stdout().execute(LeaveAlternateScreen)?;
+                        restore_terminal();
                         drop(terminal);
 
                         let update_result = perform_update(&download_url).await;
@@ -2022,13 +2053,12 @@ impl Client {
                         io::stdout().execute(EnableMouseCapture)?;
                         terminal = Terminal::new(CrosstermBackend::new(io::stdout()))?;
                         terminal.clear()?;
+                        self.update_terminal_title();
 
                         match update_result {
                             Ok(binary_path) => {
                                 // Restore terminal before exec
-                                io::stdout().execute(DisableMouseCapture)?;
-                                disable_raw_mode()?;
-                                io::stdout().execute(LeaveAlternateScreen)?;
+                                restore_terminal();
 
                                 // Shut down the daemon and wait for it to actually exit
                                 let _ = self.send_cmd(&Command::Shutdown).await;
@@ -2091,6 +2121,7 @@ impl Client {
             match self.server_rx.try_recv() {
                 Ok(Ok(ServerMessage::Snapshot(snap))) => {
                     self.view.update_from_snapshot(snap);
+                    self.update_terminal_title();
                     self.maybe_fetch_cover_image();
                 }
                 Ok(Ok(ServerMessage::Error(err))) => {
@@ -2137,9 +2168,7 @@ impl Client {
         }
 
         // Restore terminal
-        io::stdout().execute(DisableMouseCapture)?;
-        disable_raw_mode()?;
-        io::stdout().execute(LeaveAlternateScreen)?;
+        restore_terminal();
 
         if send_shutdown {
             let _ = self.send_cmd(&Command::Shutdown).await;

--- a/crates/deezer-tui/src/completions.rs
+++ b/crates/deezer-tui/src/completions.rs
@@ -1,0 +1,120 @@
+//! Shell completion generation for deezer-tui.
+
+use std::io::{self, Write};
+
+/// Generate shell completions for the specified shell.
+pub fn generate_completions(shell: &str) {
+    match shell.to_lowercase().as_str() {
+        "bash" => print_bash_completions(),
+        "zsh" => print_zsh_completions(),
+        "fish" => print_fish_completions(),
+        _ => {
+            eprintln!("Unsupported shell: '{shell}'. Supported shells: bash, zsh, fish");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn print_bash_completions() {
+    let script = r#"_deezer_tui() {
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    opts="-p --toggle --play --pause --stop -n --next -b --prev -s --status --json --volume --volume-up --volume-down --seek --seek-forward --seek-backward --shuffle --repeat --like --dislike --completions -q --quit -v --version -h --help"
+
+    case "${prev}" in
+        --completions)
+            COMPREPLY=( $(compgen -W "bash zsh fish" -- "${cur}") )
+            return 0
+            ;;
+        --volume|--volume-up|--volume-down|--seek|--seek-forward|--seek-backward)
+            return 0
+            ;;
+        *)
+            ;;
+    esac
+
+    COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+    return 0
+}
+complete -F _deezer_tui deezer-tui
+"#;
+    let _ = io::stdout().write_all(script.as_bytes());
+}
+
+fn print_zsh_completions() {
+    let script = r#"#compdef deezer-tui
+
+_deezer_tui() {
+    local -a arguments
+    arguments=(
+        '(-p --toggle)'{-p,--toggle}'[Toggle play/pause]'
+        '--play[Resume playback]'
+        '--pause[Pause playback]'
+        '--stop[Stop playback]'
+        '(-n --next)'{-n,--next}'[Skip to next track]'
+        '(-b --prev)'{-b,--prev}'[Go to previous track]'
+        '(-s --status)'{-s,--status}'[Show current playback status]'
+        '--json[Format status output as JSON]'
+        '--volume[Set volume percentage (0-100)]:volume (0-100):'
+        '--volume-up[Increase volume by percentage (default 5%)]:step:'
+        '--volume-down[Decrease volume by percentage (default 5%)]:step:'
+        '--seek[Seek to absolute position in seconds]:seconds:'
+        '--seek-forward[Seek forward by seconds]:seconds:'
+        '--seek-backward[Seek backward by seconds]:seconds:'
+        '--shuffle[Toggle shuffle mode]'
+        '--repeat[Cycle repeat mode (off -> queue -> track)]'
+        '--like[Add currently playing track to favorites]'
+        '--dislike[Dislike currently playing track]'
+        '--completions[Generate shell completions]:shell:(bash zsh fish)'
+        '(-q --quit)'{-q,--quit}'[Stop the daemon]'
+        '(-v --version)'{-v,--version}'[Show version info]'
+        '(-h --help)'{-h,--help}'[Show help message]'
+    )
+    _arguments -s $arguments
+}
+
+_deezer_tui "$@"
+"#;
+    let _ = io::stdout().write_all(script.as_bytes());
+}
+
+fn print_fish_completions() {
+    let script = r#"complete -c deezer-tui -s p -l toggle -d "Toggle play/pause"
+complete -c deezer-tui -l play -d "Resume playback"
+complete -c deezer-tui -l pause -d "Pause playback"
+complete -c deezer-tui -l stop -d "Stop playback"
+complete -c deezer-tui -s n -l next -d "Skip to next track"
+complete -c deezer-tui -s b -l prev -d "Go to previous track"
+complete -c deezer-tui -s s -l status -d "Show current playback status"
+complete -c deezer-tui -l json -d "Format status output as JSON"
+complete -c deezer-tui -l volume -d "Set volume percentage (0-100)" -x
+complete -c deezer-tui -l volume-up -d "Increase volume by percentage (default 5%)" -x
+complete -c deezer-tui -l volume-down -d "Decrease volume by percentage (default 5%)" -x
+complete -c deezer-tui -l seek -d "Seek to absolute position in seconds" -x
+complete -c deezer-tui -l seek-forward -d "Seek forward by seconds" -x
+complete -c deezer-tui -l seek-backward -d "Seek backward by seconds" -x
+complete -c deezer-tui -l shuffle -d "Toggle shuffle mode"
+complete -c deezer-tui -l repeat -d "Cycle repeat mode"
+complete -c deezer-tui -l like -d "Add current track to favorites"
+complete -c deezer-tui -l dislike -d "Dislike current track"
+complete -c deezer-tui -l completions -d "Generate shell completions" -x -a "bash zsh fish"
+complete -c deezer-tui -s q -l quit -d "Stop the daemon"
+complete -c deezer-tui -s v -l version -d "Show version info"
+complete -c deezer-tui -s h -l help -d "Show help message"
+"#;
+    let _ = io::stdout().write_all(script.as_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_completions_dont_panic() {
+        generate_completions("bash");
+        generate_completions("zsh");
+        generate_completions("fish");
+    }
+}

--- a/crates/deezer-tui/src/main.rs
+++ b/crates/deezer-tui/src/main.rs
@@ -1,4 +1,5 @@
 mod client;
+mod completions;
 mod daemon;
 mod favorites_cache;
 mod i18n;
@@ -32,6 +33,48 @@ fn init_logging(path: &str) {
     }
 }
 
+fn print_help() {
+    println!("deezer-tui — Terminal-based Deezer player");
+    println!();
+    println!("Usage: deezer-tui [OPTIONS]");
+    println!();
+    println!("Options:");
+    println!("  -p, --toggle              Toggle play/pause");
+    println!("      --play                Resume playback");
+    println!("      --pause               Pause playback");
+    println!("      --stop                Stop playback");
+    println!("  -n, --next                Skip to next track");
+    println!("  -b, --prev                Go to previous track");
+    println!("  -s, --status              Show current playback status");
+    println!("      --json                Format status output as JSON");
+    println!("      --volume <0-100>      Set volume percentage");
+    println!("      --volume-up [STEP]    Increase volume (default: 5%)");
+    println!("      --volume-down [STEP]  Decrease volume (default: 5%)");
+    println!("      --seek <SECS>         Seek to absolute position in seconds");
+    println!("      --seek-forward [SECS] Seek forward by seconds (default: 5s)");
+    println!("      --seek-backward [SECS]Seek backward by seconds (default: 5s)");
+    println!("      --shuffle             Toggle shuffle mode");
+    println!("      --repeat              Cycle repeat mode (off -> queue -> track)");
+    println!("      --like                Add currently playing track to favorites");
+    println!("      --dislike             Dislike currently playing track");
+    println!("      --completions <SHELL> Generate shell completions (bash, zsh, fish)");
+    println!("  -q, --quit                Stop the daemon");
+    println!("  -v, --version             Show version info");
+    println!("  -h, --help                Show this help message");
+}
+
+fn print_version() {
+    println!(
+        "deezer-tui {} ({}/{})",
+        env!("CARGO_PKG_VERSION"),
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+    );
+    println!("License: WTFPL");
+    println!("Author:  Tatayoyoh");
+    println!("GitHub:  https://github.com/Tatayoyoh/deezer-tui");
+}
+
 fn main() -> Result<()> {
     // Initialize i18n: config override > system locale > English
     let config = deezer_core::Config::load();
@@ -46,35 +89,139 @@ fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
 
     if args.iter().any(|a| a == "-h" || a == "--help") {
-        println!("deezer-tui — Terminal-based Deezer player");
-        println!();
-        println!("Usage: deezer-tui [OPTIONS]");
-        println!();
-        println!("Options:");
-        println!("  -p, --toggle     Toggle play/pause");
-        println!("  -n, --next       Skip to next track");
-        println!("  -b, --prev       Go to previous track");
-        println!("  -q, --quit       Stop the daemon");
-        println!("  -v, --version    Show version info");
-        println!("  -h, --help       Show this help message");
+        print_help();
         return Ok(());
     }
 
     if args.iter().any(|a| a == "-v" || a == "--version") {
-        println!(
-            "deezer-tui {} ({}/{})",
-            env!("CARGO_PKG_VERSION"),
-            std::env::consts::OS,
-            std::env::consts::ARCH,
-        );
-        println!("License: WTFPL");
-        println!("Author:  Tatayoyoh");
-        println!("GitHub:  https://github.com/Tatayoyoh/deezer-tui");
+        print_version();
         return Ok(());
+    }
+
+    // Shell completions generator
+    if let Some(pos) = args.iter().position(|a| a == "--completions") {
+        if let Some(shell) = args.get(pos + 1) {
+            completions::generate_completions(shell);
+            return Ok(());
+        } else {
+            eprintln!("Error: --completions requires a shell argument (bash, zsh, fish)");
+            std::process::exit(1);
+        }
     }
 
     if args.iter().any(|a| a == "-q" || a == "--quit") {
         return handle_quit();
+    }
+
+    // Status query
+    if args
+        .iter()
+        .any(|a| a == "-s" || a == "--status" || a == "--current")
+    {
+        let json = args.iter().any(|a| a == "--json" || a == "-j");
+        return handle_status(json);
+    }
+
+    // Volume controls
+    if let Some(pos) = args.iter().position(|a| a == "--volume") {
+        if let Some(val_str) = args.get(pos + 1) {
+            if let Ok(val) = val_str.parse::<f32>() {
+                let volume = (val / 100.0).clamp(0.0, 1.0);
+                return send_command_to_daemon(Command::SetVolume { volume });
+            } else {
+                eprintln!("Error: --volume requires a number between 0 and 100");
+                std::process::exit(1);
+            }
+        } else {
+            eprintln!("Error: --volume requires a percentage value (0-100)");
+            std::process::exit(1);
+        }
+    }
+
+    if let Some(pos) = args.iter().position(|a| a == "--volume-up") {
+        let step = args
+            .get(pos + 1)
+            .and_then(|s| s.parse::<f32>().ok())
+            .unwrap_or(5.0)
+            / 100.0;
+        if let Ok(Some(s)) = fetch_daemon_snapshot() {
+            let volume = (s.volume + step).clamp(0.0, 1.0);
+            return send_command_to_daemon(Command::SetVolume { volume });
+        } else {
+            eprintln!("deezer-tui: no daemon running");
+            return Ok(());
+        }
+    }
+
+    if let Some(pos) = args.iter().position(|a| a == "--volume-down") {
+        let step = args
+            .get(pos + 1)
+            .and_then(|s| s.parse::<f32>().ok())
+            .unwrap_or(5.0)
+            / 100.0;
+        if let Ok(Some(s)) = fetch_daemon_snapshot() {
+            let volume = (s.volume - step).clamp(0.0, 1.0);
+            return send_command_to_daemon(Command::SetVolume { volume });
+        } else {
+            eprintln!("deezer-tui: no daemon running");
+            return Ok(());
+        }
+    }
+
+    // Seek controls
+    if let Some(pos) = args.iter().position(|a| a == "--seek") {
+        if let Some(secs_str) = args.get(pos + 1) {
+            if let Ok(secs) = secs_str.parse::<u64>() {
+                return send_command_to_daemon(Command::SeekAbsolute { secs });
+            }
+        }
+        eprintln!("Error: --seek requires seconds as a positive integer");
+        std::process::exit(1);
+    }
+
+    if let Some(pos) = args.iter().position(|a| a == "--seek-forward") {
+        let secs = args
+            .get(pos + 1)
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(5);
+        return send_command_to_daemon(Command::SeekForward { secs });
+    }
+
+    if let Some(pos) = args.iter().position(|a| a == "--seek-backward") {
+        let secs = args
+            .get(pos + 1)
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(5);
+        return send_command_to_daemon(Command::SeekBackward { secs });
+    }
+
+    // Playback controls
+    if args.iter().any(|a| a == "--play") {
+        if let Ok(Some(s)) = fetch_daemon_snapshot() {
+            if s.status != deezer_core::player::state::PlaybackStatus::Playing {
+                return send_command_to_daemon(Command::TogglePause);
+            }
+            return Ok(());
+        } else {
+            eprintln!("deezer-tui: no daemon running");
+            return Ok(());
+        }
+    }
+
+    if args.iter().any(|a| a == "--pause") {
+        if let Ok(Some(s)) = fetch_daemon_snapshot() {
+            if s.status == deezer_core::player::state::PlaybackStatus::Playing {
+                return send_command_to_daemon(Command::TogglePause);
+            }
+            return Ok(());
+        } else {
+            eprintln!("deezer-tui: no daemon running");
+            return Ok(());
+        }
+    }
+
+    if args.iter().any(|a| a == "--stop") {
+        return send_command_to_daemon(Command::Stop);
     }
 
     if args.iter().any(|a| a == "-n" || a == "--next") {
@@ -85,6 +232,50 @@ fn main() -> Result<()> {
     }
     if args.iter().any(|a| a == "-p" || a == "--toggle") {
         return send_command_to_daemon(Command::TogglePause);
+    }
+    if args
+        .iter()
+        .any(|a| a == "--shuffle" || a == "--toggle-shuffle")
+    {
+        return send_command_to_daemon(Command::ToggleShuffle);
+    }
+    if args
+        .iter()
+        .any(|a| a == "--repeat" || a == "--cycle-repeat")
+    {
+        return send_command_to_daemon(Command::CycleRepeat);
+    }
+
+    if args.iter().any(|a| a == "--like") {
+        if let Ok(Some(s)) = fetch_daemon_snapshot() {
+            if let Some(track) = s.current_track {
+                return send_command_to_daemon(Command::AddFavorite {
+                    track_id: track.track_id,
+                });
+            } else {
+                eprintln!("deezer-tui: no track is currently playing");
+                return Ok(());
+            }
+        } else {
+            eprintln!("deezer-tui: no daemon running");
+            return Ok(());
+        }
+    }
+
+    if args.iter().any(|a| a == "--dislike") {
+        if let Ok(Some(s)) = fetch_daemon_snapshot() {
+            if let Some(track) = s.current_track {
+                return send_command_to_daemon(Command::DislikeTrack {
+                    track_id: track.track_id,
+                });
+            } else {
+                eprintln!("deezer-tui: no track is currently playing");
+                return Ok(());
+            }
+        } else {
+            eprintln!("deezer-tui: no daemon running");
+            return Ok(());
+        }
     }
 
     let show_updated = args.iter().any(|a| a == "--updated");
@@ -135,6 +326,109 @@ fn build_daemon_runtime() -> Result<tokio::runtime::Runtime> {
         .worker_threads(2)
         .enable_all()
         .build()?)
+}
+
+/// Fetch a single snapshot from the daemon (if alive).
+fn fetch_daemon_snapshot() -> Result<Option<crate::protocol::DaemonSnapshot>> {
+    let sock_path = socket_path();
+    if !sock_path.exists() {
+        return Ok(None);
+    }
+
+    let rt = build_client_runtime()?;
+    rt.block_on(async {
+        use crate::protocol::read_line;
+        match tokio::net::UnixStream::connect(&sock_path).await {
+            Ok(stream) => {
+                let (read_half, _write_half) = stream.into_split();
+                let mut reader = tokio::io::BufReader::new(read_half);
+                let snap = tokio::time::timeout(
+                    std::time::Duration::from_secs(2),
+                    read_line::<crate::protocol::ServerMessage, _>(&mut reader),
+                )
+                .await;
+
+                match snap {
+                    Ok(Ok(Some(crate::protocol::ServerMessage::Snapshot(s)))) => Ok(Some(s)),
+                    _ => Ok(None),
+                }
+            }
+            Err(_) => Ok(None),
+        }
+    })
+}
+
+fn format_time(secs: u64) -> String {
+    let m = secs / 60;
+    let s = secs % 60;
+    format!("{m:02}:{s:02}")
+}
+
+/// Handle `deezer-tui -s` / `--status`: query daemon and format now-playing status.
+fn handle_status(json: bool) -> Result<()> {
+    match fetch_daemon_snapshot()? {
+        Some(s) => {
+            if json {
+                let json_val = serde_json::json!({
+                    "status": match s.status {
+                        deezer_core::player::state::PlaybackStatus::Playing => "playing",
+                        deezer_core::player::state::PlaybackStatus::Paused => "paused",
+                        deezer_core::player::state::PlaybackStatus::Stopped => "stopped",
+                        deezer_core::player::state::PlaybackStatus::Loading => "loading",
+                    },
+                    "track": s.current_track.as_ref().map(|t| serde_json::json!({
+                        "id": t.track_id,
+                        "title": t.title,
+                        "artist": t.artist,
+                        "album": t.album,
+                        "duration": t.duration,
+                    })),
+                    "position_secs": s.position_secs,
+                    "duration_secs": s.duration_secs,
+                    "volume": s.volume,
+                    "volume_percent": (s.volume * 100.0).round() as u32,
+                    "shuffle": s.shuffle,
+                    "repeat": match s.repeat {
+                        deezer_core::player::state::RepeatMode::Off => "off",
+                        deezer_core::player::state::RepeatMode::Queue => "queue",
+                        deezer_core::player::state::RepeatMode::Track => "track",
+                    },
+                    "quality": format!("{:?}", s.quality),
+                });
+                println!("{}", serde_json::to_string_pretty(&json_val)?);
+            } else {
+                match (&s.status, &s.current_track) {
+                    (deezer_core::player::state::PlaybackStatus::Playing, Some(t)) => {
+                        let pos = format_time(s.position_secs);
+                        let dur = format_time(s.duration_secs);
+                        println!("▶ {} — {} [{}/{}]", t.title, t.artist, pos, dur);
+                    }
+                    (deezer_core::player::state::PlaybackStatus::Paused, Some(t)) => {
+                        let pos = format_time(s.position_secs);
+                        let dur = format_time(s.duration_secs);
+                        println!("⏸ {} — {} [{}/{}]", t.title, t.artist, pos, dur);
+                    }
+                    (deezer_core::player::state::PlaybackStatus::Loading, Some(t)) => {
+                        println!("⏳ {} — {}", t.title, t.artist);
+                    }
+                    _ => {
+                        println!("⏹ Stopped");
+                    }
+                }
+            }
+        }
+        None => {
+            if json {
+                println!(
+                    "{}",
+                    serde_json::json!({ "status": "offline", "error": "no daemon running" })
+                );
+            } else {
+                eprintln!("deezer-tui: no daemon running");
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Send a single command to the daemon and exit.
@@ -285,5 +579,20 @@ fn start_with_fork(show_updated: bool) -> Result<()> {
                 client.run(show_updated).await
             })
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_time() {
+        assert_eq!(format_time(0), "00:00");
+        assert_eq!(format_time(9), "00:09");
+        assert_eq!(format_time(59), "00:59");
+        assert_eq!(format_time(60), "01:00");
+        assert_eq!(format_time(65), "01:05");
+        assert_eq!(format_time(3600), "60:00");
     }
 }

--- a/install.sh
+++ b/install.sh
@@ -90,6 +90,34 @@ add_to_path() {
     echo "  Run: source ${RC_FILE}"
 }
 
+# Install shell completions
+install_completions() {
+    SHELL_NAME="$(basename "${SHELL:-/bin/sh}")"
+    case "${SHELL_NAME}" in
+        bash)
+            COMP_DIR="${HOME}/.local/share/bash-completion/completions"
+            mkdir -p "${COMP_DIR}"
+            if "${INSTALL_DIR}/${BINARY_NAME}" --completions bash > "${COMP_DIR}/${BINARY_NAME}" 2>/dev/null; then
+                echo "  Installed Bash completions to ${COMP_DIR}/${BINARY_NAME}"
+            fi
+            ;;
+        zsh)
+            COMP_DIR="${HOME}/.zsh/completion"
+            mkdir -p "${COMP_DIR}"
+            if "${INSTALL_DIR}/${BINARY_NAME}" --completions zsh > "${COMP_DIR}/_${BINARY_NAME}" 2>/dev/null; then
+                echo "  Installed Zsh completions to ${COMP_DIR}/_${BINARY_NAME}"
+            fi
+            ;;
+        fish)
+            COMP_DIR="${HOME}/.config/fish/completions"
+            mkdir -p "${COMP_DIR}"
+            if "${INSTALL_DIR}/${BINARY_NAME}" --completions fish > "${COMP_DIR}/${BINARY_NAME}.fish" 2>/dev/null; then
+                echo "  Installed Fish completions to ${COMP_DIR}/${BINARY_NAME}.fish"
+            fi
+            ;;
+    esac
+}
+
 echo ""
 echo "Installed ${BINARY_NAME} to ${INSTALL_DIR}/${BINARY_NAME}"
 
@@ -98,5 +126,8 @@ case ":${PATH}:" in
     *":${INSTALL_DIR}:"*) ;;
     *) add_to_path ;;
 esac
+
+# Install shell completions
+install_completions
 
 echo "Run 'deezer-tui' to start!"


### PR DESCRIPTION
- Add panic hook to safely restore terminal state on panic/crash
- Dynamically update terminal window title with playing song info and status
- Add CLI --status flag with human-readable and --json output
- Add CLI playback flags (--play, --pause, --stop, --shuffle, --repeat, --like, --dislike)
- Add shell completion generation for bash, zsh, and fish
- Automatically install shell completions in install.sh